### PR TITLE
Add split tunneling

### DIFF
--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <application
         android:name=".App"

--- a/android-app/app/src/main/java/bypass/whitelist/Constants.kt
+++ b/android-app/app/src/main/java/bypass/whitelist/Constants.kt
@@ -11,6 +11,8 @@ object PrefsKeys {
     const val URL = "url"
     const val TUNNEL_MODE = "tunnel_mode"
     const val SHOW_LOGS = "show_logs"
+    const val SPLIT_TUNNELING_MODE = "split_tunneling_mode"
+    const val SPLIT_TUNNELING_PACKAGES = "split_tunneling_packages"
 }
 
 object Vpn {

--- a/android-app/app/src/main/java/bypass/whitelist/MainActivity.kt
+++ b/android-app/app/src/main/java/bypass/whitelist/MainActivity.kt
@@ -22,12 +22,15 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import java.net.Inet4Address
 import java.net.InetAddress
+import android.widget.Toast
 
 class MainActivity : AppCompatActivity() {
 
     private var tunnelMode = TunnelMode.DC
     private var connected = false
     private var showLogs = false
+    private var splitTunnelingMode = SplitTunnelingMode.NONE
+    private var splitTunnelingPackages = mutableSetOf<String>()
 
     private val logWriter by lazy { LogWriter(cacheDir) }
     private val relay by lazy {
@@ -86,6 +89,8 @@ class MainActivity : AppCompatActivity() {
         previousUrl = Prefs.lastUrl
         urlInput.setText(previousUrl)
         tunnelMode = Prefs.tunnelMode
+        splitTunnelingMode = Prefs.splitTunnelingMode
+        splitTunnelingPackages = Prefs.splitTunnelingPackages.toMutableSet()
         statusBar.text = getString(R.string.status_format, tunnelMode.label, getString(R.string.status_idle))
         showLogs = Prefs.showLogs
         logContainer.visibility = if (showLogs) View.VISIBLE else View.GONE
@@ -152,6 +157,8 @@ class MainActivity : AppCompatActivity() {
 
     private enum class MenuItem(val id: Int, val stringRes: Int) {
         MODE(99, R.string.menu_mode),
+        SPLIT_TUNNELING(98, R.string.menu_split_tunneling),
+        SPLIT_TUNNELING_APPS(97, R.string.menu_split_tunneling_manage),
         RECONNECT_ON_START(100, R.string.menu_reconnect_on_start),
         SHOW_LOGS(101, R.string.menu_show_logs),
         SHARE_LOGS(102, R.string.menu_share_logs),
@@ -163,6 +170,12 @@ class MainActivity : AppCompatActivity() {
         val menu = popup.menu
 
         menu.add(0, MenuItem.MODE.id, 0, getString(MenuItem.MODE.stringRes, tunnelMode.label))
+
+        menu.add(0, MenuItem.SPLIT_TUNNELING.id, 0, getString(MenuItem.SPLIT_TUNNELING.stringRes, splitTunnelingMode.label))
+
+        menu.add(0, MenuItem.SPLIT_TUNNELING_APPS.id, 0, MenuItem.SPLIT_TUNNELING_APPS.stringRes).apply {
+            isEnabled = splitTunnelingMode != SplitTunnelingMode.NONE
+        }
 
         menu.add(0, MenuItem.RECONNECT_ON_START.id, 0, MenuItem.RECONNECT_ON_START.stringRes).apply {
             isCheckable = true
@@ -179,6 +192,14 @@ class MainActivity : AppCompatActivity() {
             when (item.itemId) {
                 MenuItem.RECONNECT_ON_START.id -> {
                     Prefs.connectOnStart = !item.isChecked
+                    true
+                }
+                MenuItem.SPLIT_TUNNELING.id -> {
+                    showSplitTunnelingDialog()
+                    true
+                }
+                MenuItem.SPLIT_TUNNELING_APPS.id -> {
+                    showSplitTunnelingAppSelection()
                     true
                 }
                 MenuItem.SHOW_LOGS.id -> {
@@ -221,6 +242,120 @@ class MainActivity : AppCompatActivity() {
                     TunnelVpnService.instance?.stop()
                 }
             }
+            .show()
+    }
+
+    private fun showSplitTunnelingDialog() {
+        val modes = SplitTunnelingMode.values()
+        val labels = modes.map { it.label }.toTypedArray()
+        val selectedIndex = modes.indexOf(splitTunnelingMode)
+
+        android.app.AlertDialog.Builder(this)
+            .setTitle(R.string.split_tunneling_mode_prompt)
+            .setSingleChoiceItems(labels, selectedIndex) { dialog, which ->
+                splitTunnelingMode = modes[which]
+                Prefs.splitTunnelingMode = splitTunnelingMode
+                dialog.dismiss()
+                if(TunnelVpnService.instance?.isRunning == true) {
+                    Toast.makeText(this, R.string.split_tunneling_mode_changed, Toast.LENGTH_SHORT).show()
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private data class STAppItem(val packageName: String, val label: String, val icon: android.graphics.drawable.Drawable, var isSelected: Boolean = false, val isSystemApp: Boolean = false)
+
+    private fun showSplitTunnelingAppSelection() {
+        var includeSystemApps = false
+
+        val installedPackages = packageManager.getInstalledApplications(PackageManager.GET_META_DATA)
+            .filter { it.packageName != packageName }  
+        
+        val installedApps = installedPackages.mapNotNull { appInfo ->
+            val packageName = appInfo.packageName
+            if (packageName.isBlank()) return@mapNotNull null
+            val label = appInfo.loadLabel(packageManager).toString().takeIf { it.isNotBlank() } ?: packageName
+            STAppItem(packageName, label, packageManager.getApplicationIcon(packageName), splitTunnelingPackages.contains(packageName), (appInfo.flags and android.content.pm.ApplicationInfo.FLAG_SYSTEM) == 0)
+        }.distinctBy { it.packageName }.sortedWith(compareByDescending<STAppItem> { it.isSelected }.thenBy { it.label.lowercase() })
+        
+        fun buildAppList(): List<STAppItem> {
+            return installedApps.filter { includeSystemApps || it.isSystemApp }
+        }
+
+        var items = buildAppList()
+        if (items.isEmpty()) return
+
+        val listView = android.widget.ListView(this).apply {
+            choiceMode = android.widget.ListView.CHOICE_MODE_MULTIPLE
+        }
+
+        val adapter = object : android.widget.BaseAdapter() {
+            override fun getCount() = items.size
+            override fun getItem(position: Int) = items[position]
+            override fun getItemId(position: Int) = position.toLong()
+
+            override fun getView(position: Int, convertView: android.view.View?, parent: android.view.ViewGroup): android.view.View {
+                val item = getItem(position)
+                val view = convertView ?: layoutInflater.inflate(R.layout.split_tunneling_app_list_item, parent, false)
+                val iconView = view.findViewById<android.widget.ImageView>(R.id.appIcon)
+                val labelView = view.findViewById<android.widget.TextView>(R.id.appLabel)
+                val packageView = view.findViewById<android.widget.TextView>(R.id.appPackage)
+                val checkbox = view.findViewById<android.widget.CheckBox>(R.id.appCheckbox)
+
+                iconView.setImageDrawable(item.icon)
+                labelView.text = item.label
+                val isDarkThemeEnabled = (resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK) == android.content.res.Configuration.UI_MODE_NIGHT_YES
+                labelView.setTextColor(if (isDarkThemeEnabled) android.graphics.Color.WHITE else android.graphics.Color.BLACK)
+                packageView.text = item.packageName
+
+                view.setOnClickListener {
+                    val isChecked = !checkbox.isChecked
+                    checkbox.isChecked = isChecked
+                    if (isChecked && !splitTunnelingPackages.contains(item.packageName)) splitTunnelingPackages.add(item.packageName) else if(!isChecked && splitTunnelingPackages.contains(item.packageName)) splitTunnelingPackages.remove(item.packageName)
+                    item.isSelected = isChecked
+                }
+                checkbox.setOnCheckedChangeListener { _, isChecked ->
+                    if (isChecked && !splitTunnelingPackages.contains(item.packageName)) splitTunnelingPackages.add(item.packageName) else if(!isChecked && splitTunnelingPackages.contains(item.packageName)) splitTunnelingPackages.remove(item.packageName)
+                    item.isSelected = isChecked
+                }
+
+                checkbox.isChecked = item.isSelected // do not place it before listener or else it will break everything
+
+                return view
+            }
+        }
+
+        listView.adapter = adapter
+
+        val systemAppsCheckbox = android.widget.CheckBox(this).apply {
+            text = getString(R.string.split_tunneling_show_system_apps)
+            isChecked = includeSystemApps
+            setOnCheckedChangeListener { _, checked ->
+                includeSystemApps = checked
+                items = buildAppList()
+                adapter.notifyDataSetChanged()
+            }
+        }
+
+        val dialogLayout = android.widget.LinearLayout(this).apply {
+            orientation = android.widget.LinearLayout.VERTICAL
+            setPadding(24, 24, 24, 24)
+            addView(systemAppsCheckbox)
+            addView(listView)
+        }
+
+        android.app.AlertDialog.Builder(this)
+            .setTitle(R.string.split_tunneling_apps_prompt)
+            .setView(dialogLayout)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                Prefs.splitTunnelingMode = splitTunnelingMode
+                Prefs.splitTunnelingPackages = splitTunnelingPackages
+                if(TunnelVpnService.instance?.isRunning == true) {
+                    Toast.makeText(this, R.string.split_tunneling_mode_changed, Toast.LENGTH_SHORT).show()
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
             .show()
     }
 
@@ -360,6 +495,7 @@ class MainActivity : AppCompatActivity() {
             }
 
             override fun onPageStarted(view: WebView, url: String, favicon: android.graphics.Bitmap?) {
+                if(url.contains("about:blank")) return
                 view.evaluateJavascript("""(function(){
 var oac=window.AudioContext||window.webkitAudioContext;
 if(oac){var nac=function(){var c=new oac();c.suspend();
@@ -371,6 +507,7 @@ if(oac){var nac=function(){var c=new oac();c.suspend();
             }
 
             override fun onPageFinished(view: WebView, url: String) {
+                if(url.contains("about:blank")) return
                 view.evaluateJavascript("!!window.__hookInstalled") { result ->
                     if (result == "true") {
                         Log.d("HOOK", "Hook already injected, skipping")

--- a/android-app/app/src/main/java/bypass/whitelist/Prefs.kt
+++ b/android-app/app/src/main/java/bypass/whitelist/Prefs.kt
@@ -34,4 +34,19 @@ object Prefs {
     var showLogs: Boolean
         get() = prefs.getBoolean(PrefsKeys.SHOW_LOGS, false)
         set(value) = prefs.edit { putBoolean(PrefsKeys.SHOW_LOGS, value) }
+
+    var splitTunnelingMode: SplitTunnelingMode
+        get() {
+            val title = prefs.getString(PrefsKeys.SPLIT_TUNNELING_MODE, SplitTunnelingMode.NONE.name)!!
+            return try {
+                SplitTunnelingMode.valueOf(title)
+            } catch (_: IllegalArgumentException) {
+                SplitTunnelingMode.NONE
+            }
+        }
+        set(value) = prefs.edit { putString(PrefsKeys.SPLIT_TUNNELING_MODE, value.name) }
+
+    var splitTunnelingPackages: Set<String>
+        get() = prefs.getStringSet(PrefsKeys.SPLIT_TUNNELING_PACKAGES, emptySet()) ?: emptySet()
+        set(value) = prefs.edit { putStringSet(PrefsKeys.SPLIT_TUNNELING_PACKAGES, value) }
 }

--- a/android-app/app/src/main/java/bypass/whitelist/SplitTunnelMode.kt
+++ b/android-app/app/src/main/java/bypass/whitelist/SplitTunnelMode.kt
@@ -1,0 +1,7 @@
+package bypass.whitelist
+
+enum class SplitTunnelingMode(val label: String) {
+    NONE("Off"),
+    BYPASS("Bypass"),
+    ONLY("Only")
+}

--- a/android-app/app/src/main/java/bypass/whitelist/TunnelVpnService.kt
+++ b/android-app/app/src/main/java/bypass/whitelist/TunnelVpnService.kt
@@ -18,11 +18,11 @@ class TunnelVpnService : VpnService() {
         const val CHANNEL_ID = "vpn_channel"
         const val NOTIFICATION_ID = 1
         const val ACTION_STOP = "bypass.whitelist.STOP_VPN"
-        var isRunning = false
         var instance: TunnelVpnService? = null
         var onDisconnect: (() -> Unit)? = null
     }
 
+    var isRunning: Boolean = false
     private var vpnFd: ParcelFileDescriptor? = null
     private var tun2socksThread: Thread? = null
 
@@ -81,9 +81,30 @@ class TunnelVpnService : VpnService() {
             .setMtu(Vpn.MTU)
 
         try {
-            builder.addDisallowedApplication(packageName)
+            when (Prefs.splitTunnelingMode) {
+                SplitTunnelingMode.NONE -> {
+                    builder.addDisallowedApplication(packageName)
+                }
+                SplitTunnelingMode.BYPASS -> {
+                    builder.addDisallowedApplication(packageName)
+                    Prefs.splitTunnelingPackages.forEach {
+                        try {
+                            builder.addDisallowedApplication(it)
+                        } catch (ignored: Exception) {
+                        }
+                    }
+                }
+                SplitTunnelingMode.ONLY -> {
+                    Prefs.splitTunnelingPackages.forEach {
+                        try {
+                            builder.addAllowedApplication(it)
+                        } catch (ignored: Exception) {
+                        }
+                    }
+                }
+            }
         } catch (e: Exception) {
-            Log.e(TAG, "Cannot exclude self: ${e.message}")
+            Log.e(TAG, "Split tunneling failed: ${e.message}")
         }
 
         vpnFd = builder.establish()

--- a/android-app/app/src/main/res/layout/split_tunneling_app_list_item.xml
+++ b/android-app/app/src/main/res/layout/split_tunneling_app_list_item.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="12dp"
+    android:gravity="center_vertical">
+
+    <ImageView
+        android:id="@+id/appIcon"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginEnd="12dp"
+        android:contentDescription="app icon" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/appLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:textAppearanceMedium"
+            android:textColor="@android:color/black" />
+
+        <TextView
+            android:id="@+id/appPackage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:textAppearanceSmall"
+            android:textColor="@android:color/darker_gray" />
+    </LinearLayout>
+
+    <CheckBox
+        android:id="@+id/appCheckbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -10,6 +10,12 @@
     <string name="menu_share_logs">Share logs</string>
     <string name="menu_reset">Reset</string>
     <string name="menu_mode">Mode: %1$s</string>
+    <string name="menu_split_tunneling">Split tunneling (%1$s)</string>
+    <string name="menu_split_tunneling_manage">Manage split tunneling apps</string>
+    <string name="split_tunneling_mode_prompt">Split tunneling mode</string>
+    <string name="split_tunneling_apps_prompt">Select apps</string>
+    <string name="split_tunneling_show_system_apps">Show system apps</string>
+    <string name="split_tunneling_mode_changed">Reconnect for changes to take effect</string>
     <string name="hint_call_link">Paste call link</string>
     <string name="cd_clear">Clear</string>
     <string name="cd_settings">Settings</string>


### PR DESCRIPTION
Добавил раздельное туннелирование. Оно имеет 2 режима: Bypass (выбранные приложения обходят VPN) и Only (только выбранные приложения туннелятся). Может пригодиться, если нужно пользоваться VPN одновременно с каким-нибудь трафикоемким приложением, например яндекс картами.

Теперь меню настроек приняло следующий вид:
<img width="662" height="898" alt="Gear menu" src="https://github.com/user-attachments/assets/7c0861b8-4d22-4e78-8d27-2597b372e3a7" />

Диалог с выбором режима:
<img width="1079" height="743" alt="Split tunneling mode" src="https://github.com/user-attachments/assets/33a6f077-dea1-4b7e-8f7d-38d8710ce2e6" />

Диалог с выбором приложений:
<img width="1080" height="2144" alt="Select apps" src="https://github.com/user-attachments/assets/dda15571-dbc2-4fdf-bdcd-06b1613c875a" />

Можно включить показ системных приложений:
<img width="1080" height="2149" alt="Select apps + system" src="https://github.com/user-attachments/assets/b290e9c9-db35-4465-bb0a-58207bfe070f" />


