### PR TITLE
fix: prevent duplicate call link detection

### DIFF
--- a/creator-app/vk-call-creator.js
+++ b/creator-app/vk-call-creator.js
@@ -36,6 +36,8 @@
             window.fetch = async (...args) => {
               const res = await origFetch(...args);
 
+              if (window.__CALL_LINK_CAPTURED__) return res;
+
               try {
                 const clone = res.clone();
                 const text = await clone.text();
@@ -52,6 +54,9 @@
 
                         console.log("[BOT] VKCalls: call link:", link);
                         window.__CALL_LINK__ = link;
+
+                        window.__CALL_LINK_CAPTURED__ = true;
+                        break;
                       }
                     }
                   }


### PR DESCRIPTION
Теперь бот не отправляет несколько дублирующих ссылок.
Дело в том, что при определенных действиях в текущем звонке, например при выходе участника - ссылка отлавливается заново. Создал флаг, который позволяет запретить дальнейшее отлавливание ссылок