### PR TITLE
Fix WBStream auth token loading

### DIFF
--- a/headless/wbstream-joiner/main.go
+++ b/headless/wbstream-joiner/main.go
@@ -17,6 +17,10 @@ import (
 func main() {
 	common.MaybePrintVersion()
 	roomFlag := flag.String("room", "", "WB Stream room id, wbstream://<id>, or https://stream.wb.ru/room/<id> (required)")
+	cookiesPath := flag.String("cookies", "", "path to cookies-wbstream.json")
+	localStoragePath := flag.String("local-storage", "", "path to exported stream.wb.ru localStorage")
+	accessTokenFlag := flag.String("access-token", "", "WB Stream bearer token")
+	deviceIDFlag := flag.String("device-id", "", "WB auth device id")
 	displayName := flag.String("name", "Joiner", "display name in the room")
 	socksHost := flag.String("socks-host", common.SocksLocalhostIP, "SOCKS5 listen address (use 0.0.0.0 to expose on LAN)")
 	socksPort := flag.Int("socks-port", 1080, "SOCKS5 listen port")
@@ -49,7 +53,39 @@ func main() {
 	}
 
 	roomID := wbstream.ParseRoomID(*roomFlag)
-	id, roomToken, _, serverURL, err := wbstream.AuthAndGetToken(nil, roomID, *displayName)
+	var cookieHeader string
+	if *cookiesPath != "" {
+		cookieHeader = common.FilterCookies(common.LoadCookies(*cookiesPath), wbstream.WBStreamCookieAllowlist)
+	}
+	deviceID := *deviceIDFlag
+	bearer := *accessTokenFlag
+	if *localStoragePath != "" {
+		storedBearer, storedDeviceID, err := wbstream.AccessTokenFromLocalStorageFile(*localStoragePath)
+		if err != nil {
+			log.Fatalf("[auth] localStorage: %v", err)
+		}
+		if bearer == "" {
+			bearer = storedBearer
+		}
+		if deviceID == "" {
+			deviceID = storedDeviceID
+		}
+	}
+	if bearer == "" && cookieHeader != "" && deviceID != "" {
+		refreshed, err := wbstream.RefreshAccessToken(nil, cookieHeader, deviceID)
+		if err != nil {
+			log.Printf("[auth] slide-v3 refresh failed: %v", err)
+		} else {
+			bearer = refreshed
+		}
+	}
+	var id, roomToken, serverURL string
+	var err error
+	if bearer != "" || cookieHeader != "" {
+		id, roomToken, _, serverURL, err = wbstream.AuthAsLoggedIn(nil, cookieHeader, bearer, roomID, *displayName)
+	} else {
+		id, roomToken, _, serverURL, err = wbstream.AuthAndGetToken(nil, roomID, *displayName)
+	}
 	if err != nil {
 		log.Fatalf("[auth] %v", err)
 	}

--- a/headless/wbstream/main.go
+++ b/headless/wbstream/main.go
@@ -16,6 +16,9 @@ import (
 func main() {
 	common.MaybePrintVersion()
 	cookiesPath := flag.String("cookies", "", "path to cookies-wbstream.json")
+	localStoragePath := flag.String("local-storage", "", "path to exported stream.wb.ru localStorage")
+	accessTokenFlag := flag.String("access-token", "", "WB Stream bearer token")
+	deviceIDFlag := flag.String("device-id", "", "WB auth device id")
 	roomFlag := flag.String("room", "", "WB Stream room id, wbstream://<id>, or https://stream.wb.ru/room/<id> (empty = create new)")
 	displayName := flag.String("name", "Headless", "display name in the room")
 	resources := flag.String("resources", "default", "resource mode: default, moderate, unlimited, custom")
@@ -60,16 +63,36 @@ func main() {
 		log.Fatalf("[auth] --cookies is required")
 	}
 	rawCookies := common.LoadCookies(*cookiesPath)
-	deviceID := common.CookieValue(rawCookies, "__wb_device_id")
-	if deviceID == "" {
-		log.Fatalf("[auth] cookies file is missing __wb_device_id; re-export via creator-app's 'Export Cookies' button")
-	}
 	cookieHeader := common.FilterCookies(rawCookies, wbstream.WBStreamCookieAllowlist)
-	bearer, err := wbstream.RefreshAccessToken(nil, cookieHeader, deviceID)
-	if err != nil {
-		log.Fatalf("[auth] slide-v3 refresh: %v", err)
+	deviceID := *deviceIDFlag
+	bearer := *accessTokenFlag
+	if *localStoragePath != "" {
+		storedBearer, storedDeviceID, err := wbstream.AccessTokenFromLocalStorageFile(*localStoragePath)
+		if err != nil {
+			log.Fatalf("[auth] localStorage: %v", err)
+		}
+		if bearer == "" {
+			bearer = storedBearer
+		}
+		if deviceID == "" {
+			deviceID = storedDeviceID
+		}
 	}
-	log.Printf("[auth] bearer refreshed (len=%d)", len(bearer))
+	if deviceID == "" {
+		deviceID = common.CookieValue(rawCookies, "__wb_device_id")
+	}
+	if bearer == "" && deviceID != "" {
+		refreshed, err := wbstream.RefreshAccessToken(nil, cookieHeader, deviceID)
+		if err != nil {
+			log.Printf("[auth] slide-v3 refresh failed: %v", err)
+		} else {
+			bearer = refreshed
+		}
+	}
+	if bearer == "" {
+		log.Fatalf("[auth] --access-token or --local-storage with wb_auth_auth_slice is required")
+	}
+	log.Printf("[auth] bearer loaded (len=%d)", len(bearer))
 	requestedRoom := wbstream.ParseRoomID(*roomFlag)
 	roomID, roomToken, accessToken, serverURL, err := wbstream.AuthAsLoggedIn(nil, cookieHeader, bearer, requestedRoom, *displayName)
 	if err != nil {
@@ -153,13 +176,14 @@ func main() {
 		}
 		time.Sleep(3 * time.Second)
 
-		newBearer, refreshErr := wbstream.RefreshAccessToken(nil, cookieHeader, deviceID)
-		if refreshErr != nil {
-			log.Printf("[rejoin] slide-v3 refresh failed: %v, retrying in 5s", refreshErr)
-			time.Sleep(5 * time.Second)
-			continue
+		if deviceID != "" {
+			newBearer, refreshErr := wbstream.RefreshAccessToken(nil, cookieHeader, deviceID)
+			if refreshErr != nil {
+				log.Printf("[rejoin] slide-v3 refresh failed, reusing current bearer: %v", refreshErr)
+			} else {
+				bearer = newBearer
+			}
 		}
-		bearer = newBearer
 		_, newRoomToken, newAccessToken, newServerURL, err := wbstream.AuthAsLoggedIn(nil, cookieHeader, bearer, roomID, *displayName)
 		if err != nil {
 			log.Printf("[rejoin] auth failed: %v, retrying in 5s", err)

--- a/relay/wbstream/api.go
+++ b/relay/wbstream/api.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"whitelist-bypass/relay/common"
@@ -255,6 +256,11 @@ type slideV3Response struct {
 	Payload struct {
 		AccessToken string `json:"access_token"`
 	} `json:"payload"`
+	AccessToken string `json:"access_token"`
+}
+
+type localStorageAuthSlice struct {
+	AccessToken string `json:"accessToken"`
 }
 
 func newRequestID() string {
@@ -265,6 +271,32 @@ func newRequestID() string {
 	b[6] = (b[6] & 0x0f) | 0x40
 	b[8] = (b[8] & 0x3f) | 0x80
 	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+func AccessTokenFromLocalStorageFile(path string) (string, string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", err
+	}
+	var accessToken string
+	var deviceID string
+	for _, line := range strings.Split(string(data), "\n") {
+		key, value, ok := strings.Cut(line, "\t")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "wb_auth_api_device_id":
+			deviceID = strings.TrimSpace(value)
+		case "wb_auth_auth_slice":
+			var auth localStorageAuthSlice
+			if err := json.Unmarshal([]byte(value), &auth); err != nil {
+				return "", "", fmt.Errorf("parse wb_auth_auth_slice: %w", err)
+			}
+			accessToken = auth.AccessToken
+		}
+	}
+	return accessToken, deviceID, nil
 }
 
 func RefreshAccessToken(client *http.Client, cookieHeader, deviceID string) (string, error) {
@@ -300,10 +332,14 @@ func RefreshAccessToken(client *http.Client, cookieHeader, deviceID string) (str
 	if err := json.Unmarshal(raw, &r); err != nil {
 		return "", fmt.Errorf("slide-v3 decode: %w", err)
 	}
-	if r.Payload.AccessToken == "" {
+	accessToken := r.Payload.AccessToken
+	if accessToken == "" {
+		accessToken = r.AccessToken
+	}
+	if accessToken == "" {
 		return "", fmt.Errorf("slide-v3: empty access_token in response: %s", string(raw))
 	}
-	return r.Payload.AccessToken, nil
+	return accessToken, nil
 }
 
 func joinAndGetDetails(client *http.Client, accessToken, roomID, displayName string) (string, string, string, string, error) {


### PR DESCRIPTION
## Summary

WB Stream's web auth flow no longer reliably returns a bearer token from the existing `slide-v3` refresh path for exported browser sessions. In the observed current browser flow, room APIs are called with:

- `Authorization: Bearer <token>` from `localStorage.wb_auth_auth_slice.accessToken`
- WB auth cookies such as `x_wbaas_token`, `wbx-validation-key`, and `_wbauid`
- `wb_auth_api_device_id` from localStorage when token refresh is available

This patch makes the WBStream headless tools accept that current browser-exported auth state without breaking the old anonymous guest path.

## Changes

- Add `wbstream.AccessTokenFromLocalStorageFile(path)` to read:
  - `wb_auth_auth_slice.accessToken`
  - `wb_auth_api_device_id`
- Make `RefreshAccessToken` accept both response shapes:
  - `payload.access_token`
  - top-level `access_token`
- Update `headless/wbstream` creator auth:
  - add `--local-storage`, `--access-token`, and `--device-id`
  - use localStorage/stored bearer token when refresh is unavailable
  - keep refresh as an optional update path when a device id is present
- Update `headless/wbstream-joiner` auth:
  - add `--cookies`, `--local-storage`, `--access-token`, and `--device-id`
  - use logged-in auth when browser auth state is supplied
  - preserve the existing `AuthAndGetToken` guest fallback when no browser auth is supplied

## Why

The current `headless/wbstream-joiner` only used guest registration, while current WB Stream browser joins use an authenticated bearer token plus cookies. The creator also required `__wb_device_id` in cookies, but current exports may store the device id in localStorage as `wb_auth_api_device_id` instead.

This keeps the old behavior available while allowing current browser-exported auth to work.

## Validation

Tested locally with fresh browser-exported WB auth cookies/localStorage from two accounts:

- `/usr/local/go/bin/go test ./...` in `relay`
- `/usr/local/go/bin/go test ./...` in `headless/wbstream`
- `/usr/local/go/bin/go test ./...` in `headless/wbstream-joiner`
- live smoke: creator loads bearer from localStorage, creates a room, connects to WB SFU
- live smoke: creator + joiner connect successfully with `-tunnel-mode dc`
- live smoke: creator + joiner connect successfully with `-tunnel-mode video`

No real tokens/cookies are included in this PR.
