### PR TITLE
Fix IPv6 leak in Android tun: route v6 into the tunnel

### DIFF
--- a/.github/workflows/build-android-fixed.yml
+++ b/.github/workflows/build-android-fixed.yml
@@ -1,0 +1,60 @@
+name: Build fixed Android APK
+
+on:
+  workflow_dispatch:        # запуск вручную из вкладки Actions
+  push:
+    branches: [ fix-ipv6-leak ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Go 1.26
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Install Android NDK + platform
+        run: |
+          yes | sdkmanager --licenses >/dev/null || true
+          sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0" "ndk;29.0.14206865"
+
+      - name: Install gomobile
+        run: |
+          go install golang.org/x/mobile/cmd/gomobile@latest
+          go install golang.org/x/mobile/cmd/gobind@latest
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      - name: Build gomobile .aar + relay .so
+        env:
+          ANDROID_NDK_HOME: ${{ env.ANDROID_SDK_ROOT }}/ndk/29.0.14206865
+          CGO_LDFLAGS: "-Wl,-z,max-page-size=16384"
+        run: |
+          cd relay
+          gomobile bind -v -trimpath -ldflags="-s -w" -target=android -androidapi 23 -o mobile.aar ./androidbind/
+          mkdir -p ../android-app/app/libs
+          cp mobile.aar ../android-app/app/libs/mobile.aar
+          mkdir -p ../android-app/app/src/main/jniLibs/arm64-v8a ../android-app/app/src/main/jniLibs/armeabi-v7a
+          GOOS=linux GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ../android-app/app/src/main/jniLibs/arm64-v8a/librelay.so .
+          GOOS=linux GOARCH=arm   go build -trimpath -ldflags="-s -w" -o ../android-app/app/src/main/jniLibs/armeabi-v7a/librelay.so .
+
+      - name: Build release APK
+        run: |
+          cd android-app
+          chmod +x gradlew
+          ./gradlew --no-daemon assembleRelease
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: whitelist-bypass-fixed-apk
+          path: android-app/app/build/outputs/apk/release/app-release.apk
+          if-no-files-found: error

--- a/.github/workflows/build-android-fixed.yml
+++ b/.github/workflows/build-android-fixed.yml
@@ -1,7 +1,7 @@
 name: Build fixed Android APK
 
 on:
-  workflow_dispatch:        # запуск вручную из вкладки Actions
+  workflow_dispatch:
   push:
     branches: [ fix-ipv6-leak ]
 
@@ -21,11 +21,13 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.26'
+          cache: false
 
-      - name: Install Android NDK + platform
-        run: |
-          yes | sdkmanager --licenses >/dev/null || true
-          sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0" "ndk;29.0.14206865"
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install NDK + platform
+        run: sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0" "ndk;29.0.14206865"
 
       - name: Install gomobile
         run: |
@@ -34,10 +36,9 @@ jobs:
           echo "$HOME/go/bin" >> "$GITHUB_PATH"
 
       - name: Build gomobile .aar + relay .so
-        env:
-          ANDROID_NDK_HOME: ${{ env.ANDROID_SDK_ROOT }}/ndk/29.0.14206865
-          CGO_LDFLAGS: "-Wl,-z,max-page-size=16384"
         run: |
+          export ANDROID_NDK_HOME="$ANDROID_SDK_ROOT/ndk/29.0.14206865"
+          export CGO_LDFLAGS="-Wl,-z,max-page-size=16384"
           cd relay
           gomobile bind -v -trimpath -ldflags="-s -w" -target=android -androidapi 23 -o mobile.aar ./androidbind/
           mkdir -p ../android-app/app/libs

--- a/android-app/app/src/main/java/bypass/whitelist/tunnel/TunnelVpnService.kt
+++ b/android-app/app/src/main/java/bypass/whitelist/tunnel/TunnelVpnService.kt
@@ -155,6 +155,8 @@ class TunnelVpnService : VpnService() {
             .setSession(Vpn.SESSION_NAME)
             .addAddress(Vpn.ADDRESS, Vpn.PREFIX_LENGTH)
             .addRoute(Vpn.ROUTE, 0)
+            .addAddress(Vpn.ADDRESS6, Vpn.PREFIX_LENGTH6)
+            .addRoute(Vpn.ROUTE6, 0)
             .setMtu(Vpn.MTU)
 
         when (Prefs.dnsMode) {

--- a/android-app/app/src/main/java/bypass/whitelist/util/Constants.kt
+++ b/android-app/app/src/main/java/bypass/whitelist/util/Constants.kt
@@ -84,6 +84,12 @@ object Vpn {
     const val ADDRESS = "10.0.0.2"
     const val PREFIX_LENGTH = 32
     const val ROUTE = "0.0.0.0"
+    // IPv6: capture all v6 into the tun too, otherwise v6 traffic leaks out the
+    // real interface (Happy Eyeballs picks the leaking v6 path and aborts the
+    // tunneled v4 connections). tun2socks (xjasonlyu/gVisor) routes v6 to SOCKS.
+    const val ADDRESS6 = "fd00::2"
+    const val PREFIX_LENGTH6 = 128
+    const val ROUTE6 = "::"
     const val MTU = 1500
     const val DNS_PRIMARY = "8.8.8.8"
     const val DNS_SECONDARY = "8.8.4.4"


### PR DESCRIPTION
The VpnService Builder only added an IPv4 address+route, so IPv6 traffic left via the real interface. Happy Eyeballs then preferred the leaking v6 path and aborted the tunneled v4 connections (observed: every connection to a host dies right after the TLS server flight, joiner sends MsgClose).

Add an IPv6 ULA address and a ::/0 route so all v6 is captured into the tun; tun2socks (xjasonlyu/gVisor) forwards it to SOCKS, the joiner already supports AtypIPv6 and the creator dials v6 destinations.