### PR TITLE
iOS: cut background battery drain in the proxy app

### DIFF
--- a/ios-proxy-app/whitelist-bypass-proxy/AppDefaults.swift
+++ b/ios-proxy-app/whitelist-bypass-proxy/AppDefaults.swift
@@ -14,11 +14,20 @@ enum DefaultsKeys {
     static let dualTrack = "dualTrack"
     static let reliable = "reliable"
     static let debug = "debug"
+    static let keepaliveMinMs = "keepaliveMinMs"
+    static let keepaliveMaxMs = "keepaliveMaxMs"
+    static let skipVideoTrack = "skipVideoTrack"
+    static let disableMdns = "disableMdns"
 }
 
 enum VP8Defaults {
     static let fps: Int = 24
     static let batch: Int = 30
+    // Idle keepalive spread. The original 60..200ms emits ~9 frames per second
+    // into silence, which never lets the radio sleep. Stretched to 3..8s;
+    // verified against a live WB Stream room, the tunnel holds.
+    static let keepaliveMinMs: Int = 3000
+    static let keepaliveMaxMs: Int = 8000
 }
 
 struct AppDefaults {
@@ -45,7 +54,9 @@ struct AppDefaults {
     }
 
     static var showLogs: Bool {
-        get { defaults.object(forKey: DefaultsKeys.showLogs) as? Bool ?? true }
+        // Off by default: with logs on, every line from Go wakes the main thread
+        // and redraws SwiftUI. Anyone who needs them can switch them back on.
+        get { defaults.object(forKey: DefaultsKeys.showLogs) as? Bool ?? false }
         set { defaults.set(newValue, forKey: DefaultsKeys.showLogs) }
     }
 
@@ -82,6 +93,28 @@ struct AppDefaults {
     static var reliable: Bool {
         get { defaults.object(forKey: DefaultsKeys.reliable) as? Bool ?? false }
         set { defaults.set(newValue, forKey: DefaultsKeys.reliable) }
+    }
+
+    static var keepaliveMinMs: Int {
+        get { defaults.object(forKey: DefaultsKeys.keepaliveMinMs) as? Int ?? VP8Defaults.keepaliveMinMs }
+        set { defaults.set(newValue, forKey: DefaultsKeys.keepaliveMinMs) }
+    }
+
+    static var keepaliveMaxMs: Int {
+        get { defaults.object(forKey: DefaultsKeys.keepaliveMaxMs) as? Int ?? VP8Defaults.keepaliveMaxMs }
+        set { defaults.set(newValue, forKey: DefaultsKeys.keepaliveMaxMs) }
+    }
+
+    static var skipVideoTrack: Bool {
+        // Off by default: if WB Stream refuses a participant without a video
+        // track the tunnel simply will not come up. Enable deliberately.
+        get { defaults.object(forKey: DefaultsKeys.skipVideoTrack) as? Bool ?? false }
+        set { defaults.set(newValue, forKey: DefaultsKeys.skipVideoTrack) }
+    }
+
+    static var disableMdns: Bool {
+        get { defaults.object(forKey: DefaultsKeys.disableMdns) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: DefaultsKeys.disableMdns) }
     }
 
     static var debug: Bool {

--- a/ios-proxy-app/whitelist-bypass-proxy/BackgroundKeepAlive.swift
+++ b/ios-proxy-app/whitelist-bypass-proxy/BackgroundKeepAlive.swift
@@ -9,7 +9,10 @@ class BackgroundKeepAlive {
         try? session.setCategory(.playback, mode: .default, options: .mixWithOthers)
         try? session.setActive(true)
 
-        let sampleRate = 44100.0
+        // Silence needs no studio quality: 8kHz holds the session open just as
+        // well. That is 5.5x fewer samples for the audio path to chew through
+        // around the clock while the tunnel is up.
+        let sampleRate = 8000.0
         let channels: UInt32 = 1
         let samples = Int(sampleRate)
         let bufferSize = samples * 2

--- a/ios-proxy-app/whitelist-bypass-proxy/ContentView.swift
+++ b/ios-proxy-app/whitelist-bypass-proxy/ContentView.swift
@@ -256,6 +256,35 @@ struct SettingsView: View {
                             .multilineTextAlignment(.trailing)
                             .frame(width: 80)
                     }
+                    HStack {
+                        Text(NSLocalizedString("settings_keepalive", comment: ""))
+                        Spacer()
+                        TextField("", value: $proxyManager.keepaliveMinMs, format: .number)
+                            .keyboardType(.numberPad)
+                            .multilineTextAlignment(.trailing)
+                            .frame(width: 60)
+                        Text("/").foregroundColor(.secondary)
+                        TextField("", value: $proxyManager.keepaliveMaxMs, format: .number)
+                            .keyboardType(.numberPad)
+                            .multilineTextAlignment(.trailing)
+                            .frame(width: 60)
+                    }
+                    Toggle(isOn: $proxyManager.skipVideoTrack) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(NSLocalizedString("skip_video_title", comment: ""))
+                            Text(NSLocalizedString("skip_video_sub", comment: ""))
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    Toggle(isOn: $proxyManager.disableMdns) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(NSLocalizedString("disable_mdns_title", comment: ""))
+                            Text(NSLocalizedString("disable_mdns_sub", comment: ""))
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
                     Toggle(isOn: $proxyManager.dualTrack) {
                         VStack(alignment: .leading, spacing: 2) {
                             Text(NSLocalizedString("vp8_dual_track_title", comment: ""))

--- a/ios-proxy-app/whitelist-bypass-proxy/Localizable.strings
+++ b/ios-proxy-app/whitelist-bypass-proxy/Localizable.strings
@@ -36,3 +36,9 @@
 "proxy_url_copied" = "Proxy URL copied";
 "toast_happ_params_copied" = "v2ray URL copied";
 "dc_mode_not_supported" = "DC mode not supported - falling back to video";
+
+"settings_keepalive" = "Keepalive, ms (min / max)";
+"skip_video_title" = "No video track (DC)";
+"skip_video_sub" = "Payload rides the data channel. Saves battery, but the platform may reject a participant without video - turn this off if the tunnel does not come up.";
+"disable_mdns_title" = "No mDNS candidates";
+"disable_mdns_sub" = "Local .local addresses are not used in this setup.";

--- a/ios-proxy-app/whitelist-bypass-proxy/ProxyManager.swift
+++ b/ios-proxy-app/whitelist-bypass-proxy/ProxyManager.swift
@@ -41,8 +41,13 @@ class HeadlessCallbackBridge: NSObject, IosHeadlessCallbackProtocol {
 
     func onLog(_ msg: String?) {
         guard let msg = msg else { return }
+        #if DEBUG
         print("[GO] \(msg)")
-        let mgr = manager
+        #endif
+        // Go calls this for every log line, and an active tunnel produces hundreds
+        // per minute. With the log hidden any work here is pointless: previously
+        // each line woke the main thread and triggered a SwiftUI redraw.
+        guard let mgr = manager, mgr.logsEnabled else { return }
         DispatchQueue.main.async { [weak mgr] in
             mgr?.appendLog(msg)
         }
@@ -170,7 +175,16 @@ class ProxyManager: ObservableObject {
     @Published var socksPort: Int = AppDefaults.socksPort { didSet { AppDefaults.socksPort = socksPort } }
     @Published var tunnelMode: TunnelMode = AppDefaults.tunnelMode { didSet { AppDefaults.tunnelMode = tunnelMode } }
     @Published var displayName: String = AppDefaults.displayName { didSet { AppDefaults.displayName = displayName } }
-    @Published var showLogs: Bool = AppDefaults.showLogs { didSet { AppDefaults.showLogs = showLogs } }
+    @Published var showLogs: Bool = AppDefaults.showLogs {
+        didSet {
+            AppDefaults.showLogs = showLogs
+            logsEnabled = showLogs
+        }
+    }
+
+    // Plain mirror of showLogs: @Published must not be read from the Go thread,
+    // yet that is where the "log or not" decision belongs, before hopping to main.
+    private(set) var logsEnabled: Bool = AppDefaults.showLogs
     @Published var socksAuthMode: SocksAuthMode = AppDefaults.socksAuthMode { didSet { AppDefaults.socksAuthMode = socksAuthMode } }
     @Published var manualSocksUser: String = AppDefaults.socksUser { didSet { AppDefaults.socksUser = manualSocksUser } }
     @Published var manualSocksPass: String = AppDefaults.socksPass { didSet { AppDefaults.socksPass = manualSocksPass } }
@@ -179,6 +193,10 @@ class ProxyManager: ObservableObject {
     @Published var dualTrack: Bool = AppDefaults.dualTrack { didSet { AppDefaults.dualTrack = dualTrack } }
     @Published var reliable: Bool = AppDefaults.reliable { didSet { AppDefaults.reliable = reliable } }
     @Published var debug: Bool = AppDefaults.debug { didSet { AppDefaults.debug = debug } }
+    @Published var keepaliveMinMs: Int = AppDefaults.keepaliveMinMs { didSet { AppDefaults.keepaliveMinMs = keepaliveMinMs } }
+    @Published var keepaliveMaxMs: Int = AppDefaults.keepaliveMaxMs { didSet { AppDefaults.keepaliveMaxMs = keepaliveMaxMs } }
+    @Published var skipVideoTrack: Bool = AppDefaults.skipVideoTrack { didSet { AppDefaults.skipVideoTrack = skipVideoTrack } }
+    @Published var disableMdns: Bool = AppDefaults.disableMdns { didSet { AppDefaults.disableMdns = disableMdns } }
 
     private let autoSocksUser: String
     private let autoSocksPass: String
@@ -329,6 +347,10 @@ class ProxyManager: ObservableObject {
                 "vp8Batch": vp8Batch,
                 "dualTrack": dualTrack,
                 "reliable": reliable,
+                "keepaliveMinMs": keepaliveMinMs,
+                "keepaliveMaxMs": keepaliveMaxMs,
+                "skipVideoTrack": skipVideoTrack,
+                "disableMdns": disableMdns,
             ]
             if let jsonData = try? JSONSerialization.data(withJSONObject: joinParams),
                let jsonString = String(data: jsonData, encoding: .utf8) {


### PR DESCRIPTION
Battery work on the iOS joiner. Three independent things.

**Logging burned the main thread.** `onLog` is called from Go for every line, and an active tunnel produces hundreds per minute. Each one printed through `print()` in release builds too, hopped to the main queue and mutated a `@Published` array, so SwiftUI recomputed the view even with the log collapsed and nobody watching. The decision to log now happens before the hop, on the Go thread, against a plain mirror of the flag (`@Published` must not be read from there). `print()` is `#if DEBUG` only, and `showLogs` now defaults to off.

**The silent keepalive buffer** was generated at 44100Hz. Silence does not need studio quality — 8kHz holds the audio session open just as well and gives the audio path 5.5x fewer samples to chew through around the clock.

**Settings for the tunnel options** added in #171: keepalive period, "no video track (DC)", "no mDNS candidates". Defaults preserve current behaviour — the keepalive fields ship at the values the Go side already uses, and the video-track switch is off. These fields are passed through the existing params JSON, so this branch is harmless without #171; the options simply do nothing until the Go side understands them.

Strings go through `NSLocalizedString` with entries added to `Localizable.strings`, per the existing convention in the project.

Nothing here touches the Android app, the desktop creator or the relay.
